### PR TITLE
Sync option toggles with saved state

### DIFF
--- a/src/ui.js
+++ b/src/ui.js
@@ -101,6 +101,8 @@ export function claimDaily(){
 }
 
 export function bind(){
+  E('pop').checked = game.showPop;
+  E('crit').checked = game.crit;
   E('clickArea').addEventListener('click', (e)=>{
     if(e.target.id==='target' || e.target.id==='clickArea'){
       click(e);


### PR DESCRIPTION
## Summary
- initialize settings checkboxes using saved `showPop` and `crit` values

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4e69c4948320b3fe5911e1d6a53f