### PR TITLE
feat: store timestamp before autosave

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -15,7 +15,7 @@ function tick(){
   const step = 0.1; // seconds
   const changed = addGold(game.gps * step);
   if(changed) drawAchievements();
-  if(Date.now()-lastSave>20000){ save(); lastSave=Date.now(); }
+  if(Date.now()-lastSave>20000){ game.time = Date.now(); save(); lastSave=Date.now(); }
   checkDaily();
 }
 


### PR DESCRIPTION
## Summary
- store current time before periodic autosave to preserve latest state

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa4e6c0c3483209b1d46978aa7dca4