### PR TITLE
Replace alerts with toast notifications

### DIFF
--- a/src/game.js
+++ b/src/game.js
@@ -1,3 +1,5 @@
+import { notify } from './notify.js';
+
 export const storeKey = 'idle.mvp.v1';
 
 export const game = {
@@ -113,7 +115,7 @@ export function checkAchievements(){
       game.achievements[a.id]=true;
       changed=true;
       if(a.reward){ game.gold += a.reward; game.totalGold += a.reward; }
-      alert(`업적 달성: ${a.name}!`);
+      notify(`업적 달성: ${a.name}!`);
     }
   });
   if(changed) save();
@@ -125,7 +127,10 @@ export function grantOffline(){
   const dt = Math.max(0, (now - game.time)/1000);
   const gain = game.gps * dt;
   let changed = false;
-  if(gain>0){ changed = addGold(gain); alert(`오프라인 동안 ${fmt(gain)} 골드를 벌었어! (약 ${Math.floor(dt)}초)`); }
+  if(gain>0){
+    changed = addGold(gain);
+    notify(`오프라인 동안 ${fmt(gain)} 골드를 벌었어! (약 ${Math.floor(dt)}초)`);
+  }
   game.time = now; save();
   return changed;
 }

--- a/src/notify.js
+++ b/src/notify.js
@@ -1,0 +1,33 @@
+let box;
+export function notify(text, duration=2000){
+  if(!box){
+    box = document.createElement('div');
+    Object.assign(box.style, {
+      position:'fixed',
+      bottom:'20px',
+      left:'50%',
+      transform:'translateX(-50%)',
+      display:'grid',
+      gap:'8px',
+      zIndex:'1000',
+      pointerEvents:'none'
+    });
+    document.body.appendChild(box);
+  }
+  const el = document.createElement('div');
+  el.textContent = text;
+  Object.assign(el.style, {
+    background:'var(--panel)',
+    border:'1px solid var(--line)',
+    color:'var(--txt)',
+    borderRadius:'8px',
+    padding:'8px 12px',
+    fontWeight:'600',
+    boxShadow:'0 2px 6px rgba(0,0,0,.4)',
+    opacity:'1',
+    transition:'opacity .5s'
+  });
+  box.appendChild(el);
+  setTimeout(()=>{ el.style.opacity='0'; }, duration);
+  setTimeout(()=>{ el.remove(); }, duration+500);
+}


### PR DESCRIPTION
## Summary
- add minimal toast notification module
- use toast notifications in achievement checks and offline reward

## Testing
- `npm test` (fails: missing package.json)

------
https://chatgpt.com/codex/tasks/task_e_68aa4e6cd5f48320a3b5c43038e15aca