### PR TITLE
feat: add player stats and equipment system

### DIFF
--- a/index.html
+++ b/index.html
@@ -77,24 +77,35 @@
         <div class="ad" id="adSlot">광고 슬롯(728×90) — 나중에 애드센스 코드 삽입</div>
       </section>
 
-      <aside class="col">
-        <section class="card grid">
-          <h3 style="margin:0">업그레이드</h3>
-          <div class="grid" id="store"></div>
-        </section>
-        <section class="card grid">
-          <h3 style="margin:0">업적</h3>
-          <div class="grid" id="achievements"></div>
-        </section>
-        <section class="card grid">
-          <h3 style="margin:0">설정</h3>
-          <div class="flex">
-            <label>크리티컬<input id="crit" type="checkbox" checked /></label>
-            <label>팝업 표시<input id="pop" type="checkbox" checked /></label>
-          </div>
-          <div class="footer">자동 저장: 20초마다 · 버전 0.1</div>
-        </section>
-      </aside>
+        <aside class="col">
+          <section class="card grid">
+            <h3 style="margin:0">캐릭터</h3>
+            <div>레벨: <b id="pLevel">1</b></div>
+            <div>HP: <b id="pHp">100</b></div>
+            <div>ATK: <b id="pAtk">1</b></div>
+            <div>EXP: <b id="pXp">0/100</b></div>
+          </section>
+          <section class="card grid">
+            <h3 style="margin:0">장비</h3>
+            <div class="grid" id="equipStore"></div>
+          </section>
+          <section class="card grid">
+            <h3 style="margin:0">업그레이드</h3>
+            <div class="grid" id="store"></div>
+          </section>
+          <section class="card grid">
+            <h3 style="margin:0">업적</h3>
+            <div class="grid" id="achievements"></div>
+          </section>
+          <section class="card grid">
+            <h3 style="margin:0">설정</h3>
+            <div class="flex">
+              <label>크리티컬<input id="crit" type="checkbox" checked /></label>
+              <label>팝업 표시<input id="pop" type="checkbox" checked /></label>
+            </div>
+            <div class="footer">자동 저장: 20초마다 · 버전 0.1</div>
+          </section>
+        </aside>
     </div>
 
     <p class="footer" style="margin-top:10px">© 2025 Idle Clicker MVP — 정적 파일만으로 동작. GitHub Pages 배포 가능.</p>

--- a/src/rpg.js
+++ b/src/rpg.js
@@ -1,0 +1,16 @@
+export const playerDefaults = {
+  hp: 100,
+  atk: 1,
+  level: 1,
+  xp: 0,
+  equipment: {}
+};
+
+export const equipmentList = [
+  { id:'sword', name:'검', stat:'atk', base:50, mult:1.15, bonus:1 },
+  { id:'armor', name:'방어구', stat:'hp', base:40, mult:1.15, bonus:5 }
+];
+
+export function levelExp(lvl){
+  return 100 + (lvl-1) * 50;
+}


### PR DESCRIPTION
## Summary
- add RPG module with player defaults and equipment list
- expand game state to include player stats and equipment purchasing
- expose character and equipment sections in UI

## Testing
- `node --check src/rpg.js`
- `node --check src/game.js`
- `node --check src/ui.js`
- `node --check src/main.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa52b280708320a8b26d35959f9dd3