### PR TITLE
feat: load achievements from json

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,16 @@
 - 클릭 타겟 이미지 URL 교체 가능
 - 광고 슬롯(아래 배너 위치)
 
+## 업적 추가 CLI
+`scripts/achievements-cli.js` 스크립트를 이용해 손쉽게 새 업적을 만들 수 있습니다.
+
+```bash
+node scripts/achievements-cli.js
+```
+
+실행 후 id, 이름, 설명, 달성 조건(예: `g.totalClicks >= 100`), 보상 골드를 입력하면
+`src/achievements.json`에 항목이 추가됩니다.
+
 ## 배포 (GitHub Pages, 완전 무료)
 1. 새 레포지토리 생성 (Public) — 예: `idle-clicker`
 2. 이 폴더의 파일을 업로드 (특히 `index.html` 필수)

--- a/scripts/achievements-cli.js
+++ b/scripts/achievements-cli.js
@@ -1,0 +1,28 @@
+const fs = require('fs');
+const path = require('path');
+const readline = require('readline');
+
+const rl = readline.createInterface({ input: process.stdin, output: process.stdout });
+const achievementsPath = path.join(__dirname, '..', 'src', 'achievements.json');
+
+function ask(q){
+  return new Promise(res => rl.question(q, ans => res(ans.trim())));
+}
+
+async function main(){
+  const id = await ask('id: ');
+  const name = await ask('name: ');
+  const description = await ask('description: ');
+  const condition = await ask('condition (e.g., g.totalClicks >= 100): ');
+  const rewardStr = await ask('reward: ');
+  const reward = Number(rewardStr) || 0;
+
+  const raw = fs.readFileSync(achievementsPath, 'utf8');
+  const list = JSON.parse(raw);
+  list.push({ id, name, description, condition, reward });
+  fs.writeFileSync(achievementsPath, JSON.stringify(list, null, 2));
+  console.log('Achievement added.');
+  rl.close();
+}
+
+main().catch(err => { console.error(err); rl.close(); });

--- a/src/achievements.json
+++ b/src/achievements.json
@@ -1,0 +1,16 @@
+[
+  {
+    "id": "click100",
+    "name": "클릭 100회",
+    "description": "클릭을 100번 해요",
+    "condition": "g.totalClicks >= 100",
+    "reward": 100
+  },
+  {
+    "id": "gold1000",
+    "name": "골드 1천",
+    "description": "누적 골드 1,000",
+    "condition": "g.totalGold >= 1000",
+    "reward": 200
+  }
+]

--- a/src/game.js
+++ b/src/game.js
@@ -1,5 +1,6 @@
 import { notify } from './notify.js';
 import { playerDefaults, equipmentList, levelExp } from './rpg.js';
+import achievementsData from './achievements.json' assert { type: 'json' };
 
 export const storeKey = 'idle.mvp.v1';
 
@@ -28,10 +29,10 @@ export const game = {
   player: { ...playerDefaults, equipment: {} }
 };
 
-export const achievementList = [
-  { id:'click100', name:'클릭 100회', desc:'클릭을 100번 해요', cond:g=>g.totalClicks>=100, reward:100 },
-  { id:'gold1000', name:'골드 1천', desc:'누적 골드 1,000', cond:g=>g.totalGold>=1000, reward:200 },
-];
+export const achievementList = achievementsData.map(a => ({
+  ...a,
+  cond: new Function('g', `return ${a.condition}`)
+}));
 
 export function fmt(n){
   if (!isFinite(n)) return '∞';

--- a/src/ui.js
+++ b/src/ui.js
@@ -60,7 +60,7 @@ export function drawAchievements(){
     const div = document.createElement('div');
     div.className = 'item' + (done ? ' done' : '');
     div.innerHTML = `<div style="font-weight:800">${a.name}</div>`+
-      `<div class="mut">${a.desc}</div>`+
+      `<div class="mut">${a.description}</div>`+
       `<div>${done?'✓':''}</div>`;
     box.appendChild(div);
   });


### PR DESCRIPTION
## Summary
- move achievement definitions into `src/achievements.json`
- load and parse achievement data at runtime and update UI to show descriptions
- add `scripts/achievements-cli.js` for interactive achievement creation and document usage

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open '/workspace/idle-clicker/package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68aa549b0d3c8320a089fbf3fb219e82