### PR TITLE
Ensure default SVG persists when no image set

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -5,7 +5,12 @@ load();
 recompute();
 bind();
 drawAchievements();
-if(!game.imageUrl) useSVG(); else setImage(game.imageUrl);
+if(!game.imageUrl){
+  useSVG();
+  save();
+}else{
+  setImage(game.imageUrl);
+}
 const offlineChanged = grantOffline();
 if(offlineChanged) drawAchievements();
 checkDaily();

--- a/src/ui.js
+++ b/src/ui.js
@@ -96,7 +96,7 @@ export function useSVG(){
     </g>
     <text x='50%' y='94%' fill='%23cbd5e1' font-family='system-ui' font-size='36' text-anchor='middle'>CLICK!</text>
   </svg>`);
-  game.imageUrl = svg; setImage(svg);
+  game.imageUrl = svg; setImage(svg); save();
 }
 
 export function checkDaily(){


### PR DESCRIPTION
## Summary
- Default to built-in SVG when no image URL is found and save immediately
- Persist SVG selection by saving inside `useSVG`

## Testing
- `node --check src/main.js && node --check src/ui.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68aa586d2ac883208f9119f28882bf38